### PR TITLE
Fixed typo (ERROR: The Compose file './docker-compose.yml' is invalid because:)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,10 +39,10 @@ services:
       resources:
         limits:
           memory: 1g
-        ulimits:
-          memlock:
-            soft: -1
-            hard: -1
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
 
 networks:
   esnet:


### PR DESCRIPTION
Before PR
```
es-django-example git:(master) docker-compose up -d
ERROR: The Compose file './docker-compose.yml' is invalid because:
services.elasticsearch.deploy.resources value Additional properties are not allowed ('ulimits' was unexpected)
```
After PR works great
```
WARNING: Some services (elasticsearch) use the 'deploy' key, which will be ignored. Compose does not support 'deploy' configuration - use `docker stack deploy` to deploy to a swarm.
Pulling elasticsearch (elasticsearch:5.4)...
5.4: Pulling from library/elasticsearch

```